### PR TITLE
build: fix version declaration

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -5,7 +5,7 @@
 (define scribblings '(("scribblings/fixw.scrbl" ())))
 (define pkg-desc "a Racket formatter that only fixes whitespaces")
 ;; https://semver.org/
-(define version "0.1.0")
+(define version "0.1")
 (define pkg-authors '(6cdh))
 (define license '(Apache-2.0 OR MIT))
 


### PR DESCRIPTION
I've recently [changed] `raco setup` to report invalid package versions (according to this [spec]) and I'm slowly going through all published packages that have version issues to fix them in anticipation of that change being released in 8.9.

[changed]: https://github.com/racket/racket/pull/4588
[spec]: https://docs.racket-lang.org/version/index.html#%28def._%28%28lib._version%2Futils..rkt%29._valid-version~3f%29%29